### PR TITLE
feat: support vectored operations

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::io::{IoSlice, IoSliceMut};
 use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -128,6 +129,14 @@ where
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self.0).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self.0).poll_read_vectored(cx, bufs)
+    }
 }
 
 impl<T> AsyncWrite for Arc<T>
@@ -140,6 +149,14 @@ where
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self.0).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self.0).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,5 +1,6 @@
 use std::cell::UnsafeCell;
 use std::fmt;
+use std::io::{IoSlice, IoSliceMut};
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -205,6 +206,14 @@ impl<T: AsyncRead + Unpin> AsyncRead for Mutex<T> {
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut *self.lock()).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.lock()).poll_read_vectored(cx, bufs)
+    }
 }
 
 impl<T: AsyncRead + Unpin> AsyncRead for &Mutex<T> {
@@ -215,6 +224,14 @@ impl<T: AsyncRead + Unpin> AsyncRead for &Mutex<T> {
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut *self.lock()).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.lock()).poll_read_vectored(cx, bufs)
+    }
 }
 
 impl<T: AsyncWrite + Unpin> AsyncWrite for Mutex<T> {
@@ -224,6 +241,14 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for Mutex<T> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut *self.lock()).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.lock()).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -242,6 +267,14 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for &Mutex<T> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut *self.lock()).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.lock()).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,5 +1,5 @@
 use std::cell::Cell;
-use std::io;
+use std::io::{self, IoSlice, IoSliceMut};
 use std::mem;
 use std::pin::Pin;
 use std::slice;
@@ -134,6 +134,14 @@ impl AsyncRead for Reader {
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self).poll_read_vectored(cx, bufs)
+    }
 }
 
 impl AsyncWrite for Writer {
@@ -143,6 +151,14 @@ impl AsyncWrite for Writer {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {


### PR DESCRIPTION
Eventually needs support on `pipe` as well probably, but I leave those for another day. 