### PR TITLE
Add Repository Link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "WIP"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/stjepang/piper"
 
 [dependencies]
 crossbeam-utils = "0.7.0"


### PR DESCRIPTION
Hey there, thought this would help.

I'm always looking for the GitHub link on Docs.rs. ;)