### PR TITLE
Add README and Update Crate Description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "piper"
 version = "0.1.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
-description = "WIP"
+description = "Async pipes, channels, mutexes, and more."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/stjepang/piper"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ crossbeam-utils = "0.7.0"
 futures = { version = "0.3.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-smol = { git = "ssh://git@github.com/stjepang/smol.git" }
+smol = { git = "https://github.com/stjepang/smol.git" }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Piper
+
+Async pipes, channels, mutexes, and more.
+
+> **NOTE:** This crate is still a work in progress. Coming soon.
+
+- Arc and Mutex - same as std except they implement asyncread/asyncwrite
+- Event - for notifying async tasks and threads, advanced AtomicWaker
+- Lock - async lock
+- chan - Sender and Receiver implement Sink and Stream
+- pipe - Reader and Writer implement AsyncRead and AsyncWrite
+
+## TODO's
+
+ - change w.await to listener.await

--- a/modoc.config
+++ b/modoc.config
@@ -1,0 +1,3 @@
+# Config file for modoc: https://github.com/kurtlawrence/cargo-modoc.
+# Used to update the lib.rs module documentation from the README
+"README.md" = [ "src/lib.rs" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
+//! # Piper
+//!
 //! Async pipes, channels, mutexes, and more.
 //!
-//! **NOTE:** This crate is still a work in progress. Coming soon.
-//!
-//! TODO: change w.await to listener.await
-//!
-//! TODO:
+//! > **NOTE:** This crate is still a work in progress. Coming soon.
 //!
 //! - Arc and Mutex - same as std except they implement asyncread/asyncwrite
 //! - Event - for notifying async tasks and threads, advanced AtomicWaker
 //! - Lock - async lock
 //! - chan - Sender and Receiver implement Sink and Stream
 //! - pipe - Reader and Writer implement AsyncRead and AsyncWrite
+//!
+//! ## TODO's
+//!
+//!  - change w.await to listener.await
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 


### PR DESCRIPTION
I'm using [cargo modoc](https://github.com/kurtlawrence/cargo-modoc) to sync the REAME and the lib.rs comment for now. Not sure if you want to keep it like that, but I figured I'd throw a readme up real quick if it helped. :)

Also changes the `dev-dependency` on smol to use HTTPS instead of SSH.