### PR TITLE
Doc: fix some doc errors

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -49,7 +49,7 @@ impl<T> Arc<T> {
     ///
     /// // These two lines are equivalent:
     /// let a = Arc::new(7);
-    /// let a = Arc(sync::Arc::new(7));
+    /// let a = Arc::new(sync::Arc::new(7));
     /// ```
     pub fn new(data: T) -> Arc<T> {
         Arc(std::sync::Arc::new(data))

--- a/src/chan.rs
+++ b/src/chan.rs
@@ -34,25 +34,23 @@ use crate::event::{Event, EventListener};
 /// # Examples
 ///
 /// ```
-/// # async_std::task::block_on(async {
+/// # smol::block_on(async {
 /// #
 /// use std::time::Duration;
 ///
-/// use async_std::sync::channel;
-/// use async_std::task;
 ///
-/// let (s, r) = channel(1);
+/// let (s, r) = piper::chan::<i32>(1);
 ///
 /// // This call returns immediately because there is enough space in the channel.
 /// s.send(1).await;
 ///
-/// task::spawn(async move {
+/// smol::Task::spawn(async move {
 ///     // This call will have to wait because the channel is full.
 ///     // It will be able to complete only after the first message is received.
 ///     s.send(2).await;
 /// });
 ///
-/// task::sleep(Duration::from_secs(1)).await;
+/// smol::Timer::after(Duration::from_secs(1)).await;
 /// assert_eq!(r.recv().await, Some(1));
 /// assert_eq!(r.recv().await, Some(2));
 /// #
@@ -81,16 +79,14 @@ pub fn chan<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// # Examples
 ///
 /// ```
-/// # async_std::task::block_on(async {
+/// # smol::block_on(async {
 /// #
-/// use async_std::sync::channel;
-/// use async_std::task;
 ///
-/// let (s1, r) = channel(100);
+/// let (s1, r) = piper::chan::<i32>(100);
 /// let s2 = s1.clone();
 ///
-/// task::spawn(async move { s1.send(1).await });
-/// task::spawn(async move { s2.send(2).await });
+/// smol::Task::spawn(async move { s1.send(1).await });
+/// smol::Task::spawn(async move { s2.send(2).await });
 ///
 /// let msg1 = r.recv().await.unwrap();
 /// let msg2 = r.recv().await.unwrap();
@@ -123,14 +119,12 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    /// use async_std::task;
     ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
-    /// task::spawn(async move {
+    /// smol::Task::spawn(async move {
     ///     s.send(1).await;
     ///     s.send(2).await;
     /// });
@@ -359,18 +353,16 @@ impl<T> fmt::Debug for Sender<T> {
 /// # Examples
 ///
 /// ```
-/// # async_std::task::block_on(async {
+/// # smol::block_on(async {
 /// #
 /// use std::time::Duration;
 ///
-/// use async_std::sync::channel;
-/// use async_std::task;
 ///
-/// let (s, r) = channel(100);
+/// let (s, r) = piper::chan::<i32>(100);
 ///
-/// task::spawn(async move {
+/// smol::Task::spawn(async move {
 ///     s.send(1).await;
-///     task::sleep(Duration::from_secs(1)).await;
+///     smol::Timer::after(Duration::from_secs(1)).await;
 ///     s.send(2).await;
 /// });
 ///
@@ -403,14 +395,12 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    /// use async_std::task;
     ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
-    /// task::spawn(async move {
+    /// smol::Task::spawn(async move {
     ///     s.send(1).await;
     ///     s.send(2).await;
     /// });

--- a/src/chan.rs
+++ b/src/chan.rs
@@ -150,9 +150,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, _) = channel::<i32>(5);
+    /// let (s, _) = piper::chan::<i32>(5);
     /// assert_eq!(s.capacity(), 5);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -168,11 +166,9 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
     /// assert!(s.is_empty());
     /// s.send(0).await;
@@ -189,11 +185,9 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
     /// assert!(!s.is_full());
     /// s.send(0).await;
@@ -210,11 +204,9 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(2);
+    /// let (s, r) = piper::chan::<i32>(2);
     /// assert_eq!(s.len(), 0);
     ///
     /// s.send(1).await;
@@ -438,9 +430,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_std::sync::channel;
-    ///
-    /// let (_, r) = channel::<i32>(5);
+    /// let (_, r) = piper::chan::<i32>(5);
     /// assert_eq!(r.capacity(), 5);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -456,11 +446,9 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
     /// assert!(r.is_empty());
     /// s.send(0).await;
@@ -477,11 +465,9 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(1);
+    /// let (s, r) = piper::chan::<i32>(1);
     ///
     /// assert!(!r.is_full());
     /// s.send(0).await;
@@ -498,11 +484,9 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # smol::block_on(async {
     /// #
-    /// use async_std::sync::channel;
-    ///
-    /// let (s, r) = channel(2);
+    /// let (s, r) = piper::chan::<i32>(2);
     /// assert_eq!(r.len(), 0);
     ///
     /// s.send(1).await;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -123,7 +123,7 @@ impl<T> Mutex<T> {
     /// use piper::Mutex;
     ///
     /// let mutex = Mutex::new(10);
-    /// if let Ok(guard) = mutex.try_lock() {
+    /// if let Some(guard) = mutex.try_lock() {
     ///     assert_eq!(*guard, 10);
     /// }
     /// # ;


### PR DESCRIPTION
Hi stjepang,

The arc.rs and mutex.rs doc errors were fixed. And have replaced async_std to smol in chan.rs, but still have some doc codes cannot pass the test, the test output is in the following

```
error[E0277]: `*mut piper::chan::Slot<i32>` cannot be sent between threads safely
  --> src/chan.rs:47:1
   |
14 | smol::Task::spawn(async move {
   | ^^^^^^^^^^^^^^^^^ `*mut piper::chan::Slot<i32>` cannot be sent between threads safely
   |
   = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `*mut piper::chan::Slot<i32>`

```

Please review it. thank you.
