### PR TITLE
Refer to all used futures crates explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/stjepang/piper"
 crossbeam-utils = "0.7.0"
 futures-sink = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
-futures-core = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ repository = "https://github.com/stjepang/piper"
 
 [dependencies]
 crossbeam-utils = "0.7.0"
-futures = { version = "0.3.4", default-features = false, features = ["std"] }
+futures-sink = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-core = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 smol = { git = "https://github.com/stjepang/smol.git" }
+futures = { version = "0.3.4", default-features = false, features = ["std"] }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::io::{self, AsyncRead, AsyncWrite};
+use futures_io::{self as io, AsyncRead, AsyncWrite};
 
 /// A reference-counted pointer that implements async I/O traits.
 ///

--- a/src/chan.rs
+++ b/src/chan.rs
@@ -15,7 +15,7 @@ use std::task::{Context, Poll};
 use crossbeam_utils::Backoff;
 use futures_util::future;
 use futures_sink::Sink;
-use futures_core::Stream;
+use futures_util::stream::Stream;
 
 use crate::event::{Event, EventListener};
 
@@ -277,7 +277,7 @@ impl<T> Sink<T> for Sender<T> {
         loop {
             // If this sink is blocked on an event, first make sure it is unblocked.
             if let Some(listener) = self.listener.as_mut() {
-                futures_core::ready!(Pin::new(listener).poll(cx));
+                futures_util::ready!(Pin::new(listener).poll(cx));
                 self.listener = None;
             }
 
@@ -548,7 +548,7 @@ impl<T> Stream for Receiver<T> {
         loop {
             // If this stream is blocked on an event, first make sure it is unblocked.
             if let Some(listener) = self.listener.as_mut() {
-                futures_core::ready!(Pin::new(listener).poll(cx));
+                futures_util::ready!(Pin::new(listener).poll(cx));
                 self.listener = None;
             }
 

--- a/src/chan.rs
+++ b/src/chan.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crossbeam_utils::Backoff;
-use futures::future;
-use futures::sink::Sink;
-use futures::stream::Stream;
+use futures_util::future;
+use futures_sink::Sink;
+use futures_core::Stream;
 
 use crate::event::{Event, EventListener};
 
@@ -277,7 +277,7 @@ impl<T> Sink<T> for Sender<T> {
         loop {
             // If this sink is blocked on an event, first make sure it is unblocked.
             if let Some(listener) = self.listener.as_mut() {
-                futures::ready!(Pin::new(listener).poll(cx));
+                futures_core::ready!(Pin::new(listener).poll(cx));
                 self.listener = None;
             }
 
@@ -548,7 +548,7 @@ impl<T> Stream for Receiver<T> {
         loop {
             // If this stream is blocked on an event, first make sure it is unblocked.
             if let Some(listener) = self.listener.as_mut() {
-                futures::ready!(Pin::new(listener).poll(cx));
+                futures_core::ready!(Pin::new(listener).poll(cx));
                 self.listener = None;
             }
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 use crate::event::Event;
 
 use crossbeam_utils::Backoff;
-use futures::io::{self, AsyncRead, AsyncWrite};
+use futures_io::{self as io, AsyncRead, AsyncWrite};
 
 /// A mutex that implements async I/O traits.
 ///

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{self, AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::task::AtomicWaker;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::task::AtomicWaker;
 
 /// Creates a bounded single-producer single-consumer pipe.
 ///


### PR DESCRIPTION
This reduces the amount of compiled dependencies from 30 to 29, and compile time (`cargo check`) by a mere 0.5s.

I think these changes make sense if applied across all crates related to smol for the potential of faster builds.

Something that it helps me with is to actually know what's used by these crates, which makes understanding how they work easier.